### PR TITLE
Fixing to work with latest puppet/ubuntu1404

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class apt (
   }
 
   case $::osfamily {
-    Debian: {
+    /Debian/: {
       $supported              = true
       $periodic_config        = '/etc/apt/apt.conf.d/10periodic'
       $periodic_config_tpl    = 'periodic.erb'


### PR DESCRIPTION
When using within our organisation, this module failed with "The apt module is not supported on Debian based systems". It seemed that it was this case that was broken and so I changed it to this, which fixed the problem.
